### PR TITLE
Move package-tracker to different organisation

### DIFF
--- a/CMLibStorage.cmake
+++ b/CMLibStorage.cmake
@@ -1,3 +1,3 @@
 SET(STORAGE_LIST DEP)
 
-SET(STORAGE_LIST_DEP "https://github.com/bringauto/package-tracker.git")
+SET(STORAGE_LIST_DEP "https://github.com/bacpack-system/package-tracker.git")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,8 +1,8 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
-BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(protobuf                 v4.21.12)
 BA_PACKAGE_LIBRARY(zlib                     v1.2.11)
 IF (BRINGAUTO_SAMPLES)
-    BA_PACKAGE_LIBRARY(nlohmann-json v3.10.5 PLATFORM_STRING_MODE any_machine NO_DEBUG ON)
+    BA_PACKAGE_LIBRARY(nlohmann-json v3.10.5 NO_DEBUG ON)
 endif()


### PR DESCRIPTION
- [x] Change package tracker url
- [x] Remove any_machine flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the source used for retrieving package tracking components.
  - Simplified function calls for library dependencies by removing platform-specific parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->