### PR TITLE
Use char instead of char8_t

### DIFF
--- a/source/Context.cpp
+++ b/source/Context.cpp
@@ -13,6 +13,9 @@
 #include <unistd.h>
 
 
+static_assert(sizeof(char) == 1, "Size of char must be 1 byte");
+
+
 int Context::createConnection(const char *ipv4_address, unsigned int port) {
 	if ((socket_ = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
 		return NOT_OK; // Socket creation error
@@ -20,7 +23,7 @@ int Context::createConnection(const char *ipv4_address, unsigned int port) {
 
 	int flag = 1;
 	// Set TCP_NODELAY to disable Nagle's algorithm
-	if (setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char8_t *)&flag, sizeof(int)) < 0) {
+	if (setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
 		return NOT_OK; // Failed to set TCP_NODELAY
 	}
 
@@ -44,7 +47,7 @@ int Context::reconnect() {
 
 	int flag = 1;
 	// Set TCP_NODELAY to disable Nagle's algorithm
-	if (setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char8_t *)&flag, sizeof(int)) < 0) {
+	if (setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
 		return NOT_OK; // Failed to set TCP_NODELAY
 	}
 


### PR DESCRIPTION
char8_t is not known by old compilers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type handling for network option settings to ensure compatibility.
* **Chores**
  * Added an internal check to confirm system compatibility regarding character size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->