### PR TITLE
bump fleet-protocol-interface to v2.1.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
-BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.1.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(protobuf                 v4.21.12)
 BA_PACKAGE_LIBRARY(zlib                     v1.2.11)
 IF (BRINGAUTO_SAMPLES)


### PR DESCRIPTION
`fleet-protocol-interface v2.0.0` was removed from the gitea package repository; only `v2.1.0` remains, so the dependency download fails at CMake configure. Bumping the pin to v2.1.0.